### PR TITLE
feat(k8s): promote v2 to hass.angryninja.cloud (cutover plan 05-01)

### DIFF
--- a/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
@@ -112,7 +112,7 @@ spec:
         enabled: false
         className: internal
         hosts:
-          - host: &host "hass-v2.${SECRET_DOMAIN}"
+          - host: &host "hass.${SECRET_DOMAIN}"
             paths:
               - path: /
                 service:

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -181,7 +181,7 @@ spec:
 
     route:
       app:
-        enabled: true
+        enabled: false
         annotations:
           external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
           external-dns.home.arpa/enabled: "true"


### PR DESCRIPTION
## Summary
- Switch v2 HelmRelease ingress hostname `hass-v2.${SECRET_DOMAIN}` → `hass.${SECRET_DOMAIN}` (anchor at line 115; auto-propagates to route.hostnames + tls.hosts).
- Disable v1 HelmRelease `route.app.enabled` (line 184: `true` → `false`) to prevent Envoy Gateway duplicate hostname conflict.

## Pre-merge dependency (HUMAN STEP — already complete)
Doppler key `HASS_V2_RECORDER_DB_URL` updated to production PostgreSQL DB (D-02 — atomic with hostname switch). Verify in Doppler UI before merging.

## Cross-repo context
- home-assistant-config: `.planning/phases/05-production-cutover/05-01-PLAN.md`
- Requirements: CUT-02 (hostname), CUT-07 (zero downtime — v1 stays as rollback)
- Decisions: D-01 (sequencing), D-02 (atomic DB switch)

## Test plan
- [ ] Flux reconciles HelmRelease without error: `flux get helmrelease -n home`
- [ ] v2 pod restarts after Helm upgrade (Helm controller triggers, no Stakater needed)
- [ ] curl https://hass.angryninja.cloud/ returns HTTP 200 or 302 (NOT 503/404)
- [ ] curl https://hass-v2.angryninja.cloud/ no longer resolves to v2 (the v2 route now claims hass.${SECRET_DOMAIN} only)
- [ ] HA UI History panel shows entity history (confirms recorder is connected to production DB)
- [ ] No Envoy Gateway error logs about duplicate hostnames

## Rollback
Revert this PR. Flux reconciles within 30m (or `flux reconcile kustomization home-assistant-v2 -n flux-system`). v1 route re-enables; v2 reverts to `hass-v2.${SECRET_DOMAIN}`. Doppler HASS_V2_RECORDER_DB_URL must also be reverted manually.