### PR TITLE
feat(k8s): scale v1 home-assistant to 0 replicas

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -23,6 +23,7 @@ spec:
   values:
     controllers:
       home-assistant:
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:


### PR DESCRIPTION
## Summary
- Sets `replicas: 0` on the v1 home-assistant controller
- v2 is live on hass.bakerhaus.cloud, v1 route already disabled (#1051)
- Stops the v1 pod while keeping all k8s resources intact for rollback

## Rollback
Remove `replicas: 0` and re-enable the v1 route in helmrelease.yaml.

## Next
Full v1 decommission (plan 05-03) after 1-week soak with zero incidents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)