### PR TITLE
chore: update GitHub username from angryninja48 to jbaker48

### DIFF
--- a/kubernetes/apps/ai/garmin-ai-coach/app/pullsecret.yaml
+++ b/kubernetes/apps/ai/garmin-ai-coach/app/pullsecret.yaml
@@ -16,7 +16,7 @@ spec:
       type: kubernetes.io/dockerconfigjson
       engineVersion: v2
       data:
-        .dockerconfigjson: '{"auths":{"ghcr.io":{"auth":"{{ printf "angryninja48:%s" .GARMIN_AI_COACH_GHCR_TOKEN | b64enc }}"}}}'
+        .dockerconfigjson: '{"auths":{"ghcr.io":{"auth":"{{ printf "jbaker48:%s" .GARMIN_AI_COACH_GHCR_TOKEN | b64enc }}"}}}'
   data:
     - secretKey: GARMIN_AI_COACH_GHCR_TOKEN
       remoteRef:

--- a/kubernetes/apps/ai/garmin-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/garmin-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/angryninja48/garmin_mcp
+              repository: ghcr.io/jbaker48/garmin_mcp
               tag: sha-1933f37
             env:
               TZ: ${TIMEZONE}

--- a/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
+++ b/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
     - name: actions-runner-controller
       namespace: arc-systems
   values:
-    githubConfigUrl: "https://github.com/angryninja48/home-assistant-config"
+    githubConfigUrl: "https://github.com/jbaker48/home-assistant-config"
     githubConfigSecret: arc-github-secret
     minRunners: 0
     maxRunners: 1

--- a/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
                   echo "Git sync complete"
                 else
                   echo "Cloning repository..."
-                  git clone -b ha-v2-config git@github.com:angryninja48/home-assistant-config.git /config
+                  git clone -b ha-v2-config git@github.com:jbaker48/home-assistant-config.git /config
                   echo "Clone complete"
                 fi
             securityContext:

--- a/kubernetes/flux/config/cluster.yaml
+++ b/kubernetes/flux/config/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30m
-  url: "https://github.com/angryninja48/k8s-cluster"
+  url: "https://github.com/jbaker48/k8s-cluster"
   secretRef:
     name: github-deploy-key
   ref:


### PR DESCRIPTION
## Summary

- Update `githubConfigUrl` in `ha-restarter` HelmRelease — fixes ARC runner 404 on registration, unblocking the HA restart workflow
- Update git-sync clone URL in `home-assistant-v2` HelmRelease
- Update Flux `GitRepository` source URL for `k8s-cluster`
- Update GHCR image reference for `garmin-mcp`
- Update GHCR pull secret auth username for `garmin-ai-coach`

Root cause: GitHub username renamed from `angryninja48` → `jbaker48`. GitHub API calls (ARC runner registration) do not follow username redirects, causing the `ha-restarter` listener to error and all HA restart jobs to queue indefinitely.

## Test plan

- [ ] ARC `ha-restarter` listener pod starts without error after Flux applies
- [ ] Push to `ha-v2-config` triggers a queued job that runs (not stuck)
- [ ] HA pod restarts successfully after next push
- [ ] `garmin-mcp` and `garmin-ai-coach` continue pulling images from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)