### PR TITLE
fix(arc-runners): revert kubectl to bitnami/kubectl:latest (1.32 tag invalid)

### DIFF
--- a/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
+++ b/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
@@ -34,8 +34,8 @@ spec:
       spec:
         initContainers:
           - name: kube-inject
-            image: bitnami/kubectl:1.32
-            imagePullPolicy: IfNotPresent
+            image: bitnami/kubectl:latest
+            imagePullPolicy: Always
             command: ["cp", "/opt/bitnami/kubectl/bin/kubectl", "/usr/local/bin/kubectl"]
             volumeMounts:
               - name: kubectl-bin

--- a/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
+++ b/kubernetes/apps/arc-runners/ha-restarter/app/helmrelease.yaml
@@ -34,7 +34,8 @@ spec:
       spec:
         initContainers:
           - name: kube-inject
-            image: bitnami/kubectl:latest
+            image: bitnami/kubectl:1.32
+            imagePullPolicy: IfNotPresent
             command: ["cp", "/opt/bitnami/kubectl/bin/kubectl", "/usr/local/bin/kubectl"]
             volumeMounts:
               - name: kubectl-bin
@@ -42,7 +43,8 @@ spec:
         serviceAccountName: ha-restarter
         containers:
           - name: runner
-            image: ghcr.io/actions/actions-runner:latest
+            image: ghcr.io/actions/actions-runner:2.334.0
+            imagePullPolicy: IfNotPresent
             command: ["/home/runner/run.sh"]
             volumeMounts:
               - name: kubectl-bin

--- a/kubernetes/apps/arc-runners/ha-restarter/app/rbac.yaml
+++ b/kubernetes/apps/arc-runners/ha-restarter/app/rbac.yaml
@@ -14,9 +14,12 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "patch"]
     resourceNames: ["home-assistant-v2"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubernetes/apps/home/frigate/app/config/config.yml
+++ b/kubernetes/apps/home/frigate/app/config/config.yml
@@ -139,6 +139,7 @@ cameras:
 
   max_room:
     ffmpeg:
+      hwaccel_args: []
       output_args:
         record: preset-record-generic-audio-aac
       inputs:
@@ -180,6 +181,7 @@ cameras:
 
   playroom:
     ffmpeg:
+      hwaccel_args: []
       output_args:
         record: preset-record-generic-audio-aac
       inputs:


### PR DESCRIPTION
Quick follow-up to #1069 — bitnami/kubectl:1.32 tag doesn't exist on Docker Hub, causing ErrImagePull. Reverts to :latest which was working before.