### PR TITLE
feat(evcc): switch grid tariff to GloBird fixed-with-zones

### DIFF
--- a/kubernetes/apps/home/evcc/app/config/evcc.yaml
+++ b/kubernetes/apps/home/evcc/app/config/evcc.yaml
@@ -97,17 +97,19 @@ tariffs:
   #     timeout: 10m
       # jq: .spot_per_kwh
   grid:
-    type: template
-    template: amber
-    token: {{ .AMBER_ACCESS_TOKEN }}
-    siteid: {{ .AMBER_SITE_ID }}      # Different from token - find in Amber app
-    channel: general
+    type: fixed
+    price: 0.363          # Shoulder default — applies to any hour not in a zone
+    zones:
+      - hours: 11-14
+        price: 0          # Free window (11:00–13:59)
+      - hours: 16-23
+        price: 0.495      # Peak window (16:00–22:59)
   feedin:
-    type: template
-    template: amber
-    token: {{ .AMBER_ACCESS_TOKEN }}
-    siteid: {{ .AMBER_SITE_ID }}
-    channel: feedIn
+    type: fixed
+    price: 0.05           # Standard FIT
+    zones:
+      - hours: 18-21
+        price: 0.15       # Super FIT (18:00–20:59)
   co2:
     type: template
     template: electricitymaps-free


### PR DESCRIPTION
## Summary

Switches EVCC's grid tariff from the Amber template (polling Amber Electric API)
to EVCC's native `type: fixed` tariff with GloBird ZEROHERO time-of-day zones:

- Grid: 0.0 (11:00–13:59), 0.495 (16:00–22:59), 0.363 default shoulder
- Feedin: 0.05 default, 0.15 (18:00–20:59 Super FIT)

EVCC's PV-mode charging will use these prices to forced-charge the EV only
during the free window, replacing the previous Amber-price-spike-reactive
behavior. No HA-side override needed.

## Test Plan

- [ ] CI (kustomize + Flux dry-run) green
- [ ] After Flux reconcile, EVCC container restarts cleanly with new ConfigMap
- [ ] EVCC UI (https://evcc.bakerhaus.cloud or internal route) shows tariff
      table with zones rendered correctly
- [ ] No tariff fetch errors in EVCC container logs
- [ ] Over the next 7 days, EV charging activity occurs only between 11:00 and 14:00

## Cross-repo dependency

Pair PR in home-assistant-config: Phase 9 plan 09-01 (tariffs.yaml). This PR
can merge BEFORE the HA-side PR — EVCC will operate on the new tariff
immediately; HA continues running Amber-driven cost sensors until 09-01 lands.

## Links

- Phase 9 master plan: `home-assistant-config/.planning/phases/09-globird-zerohero-tariff-migration/09-PLAN.md`
- This sub-plan: `home-assistant-config/.planning/phases/09-globird-zerohero-tariff-migration/09-04-PLAN.md`
- Research: `home-assistant-config/.planning/phases/09-globird-zerohero-tariff-migration/09-RESEARCH.md`
- EVCC docs: https://docs.evcc.io/en/features/dynamic-prices/

## Notes

- `AMBER_ACCESS_TOKEN` and `AMBER_SITE_ID` env vars in the EVCC ExternalSecret
  become unused but are not removed in this PR. Follow-up cluster PR will
  clean them up after a stable observation period.
- `loadpoints[].mode` unchanged.
- `co2:` block preserved if previously present.