### PR TITLE
chore(home-assistant-v2): upgrade image to 2026.7.1

### DIFF
--- a/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant-v2/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2026.3.3@sha256:16c50c92379b507ef0de98ea5371f2a0cabf917991d9f7d1c52f612c5557388a
+              tag: 2026.7.1@sha256:77612bf97ff111c5517f708b7893e6d4400e0104db24cdd69e30105c95b7bfcc
             # command:
             #   - python3
             #   - -m


### PR DESCRIPTION
## Summary

Bumps the HA v2 HelmRelease image from `2026.3.3` to `2026.7.1`, needed to unblock kiosk-mode v14.0.1 (already installed via HACS on the live instance), which requires HA >=2026.6.0.

**Depends on:** jbaker48/home-assistant-config#199 must merge and deploy first. HA 2026.6 removed the legacy `platform: template` entity syntax, which `cover.garage_door` and two placeholder lights (`light.placeholder_office`, `light.placeholder_bathroom`) used — that PR migrates them to the modern `template:` syntax. Bumping this image before that config change deploys would break those three entities.

Full breaking-change research (2026.4 → 2026.7) is documented in the companion PR — only the template-entity removal applies to this setup.

## Notes for Reviewer

- Digest resolved via `docker pull ghcr.io/home-operations/home-assistant:2026.7.1` + `docker inspect` (repo already tracks digest-pinned tags for this image).
- There's a stale, unrelated `renovate/ghcr.io-home-operations-home-assistant-2026.x` branch in this repo that bumps only to `2026.5.2` (insufficient — below the 2026.6.0 floor) and also reverts the git-sync clone URL to an old GitHub username (`angryninja48` instead of current `jbaker48`) and deletes `backendtrafficpolicy.yaml`. That branch was not used as a base for this PR — confirmed with repo owner it's stale/should not be merged as-is.
- Only the image `tag:` line changed — no other HelmRelease fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)