### PR TITLE
test: exclusion-gate recheck after CR-02 rewrite (expect flag)

### DIFF
--- a/kubernetes/flux/repositories/helm/cilium.yaml
+++ b/kubernetes/flux/repositories/helm/cilium.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   interval: 1h
   url: https://helm.cilium.io
+# test: exclusion-gate recheck after CR-02 generic-category rewrite


### PR DESCRIPTION
Throwaway verification PR for the code-review fixes in 02a1b0ee. Confirms the rewritten generic category-matching logic still flags a dual-category (kubernetes-core + cilium) change. Will be closed and the branch deleted immediately after verification.