### PR TITLE
test(05-05): hard-exclusion regression + notify-exclusion throwaway test

### DIFF
--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -5,6 +5,7 @@ talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.3
 
+# gsd-test: 05-05 Test 3 hard-exclusion regression + notify-exclusion throwaway test
 clusterName: &clusterName "home-kubernetes"
 endpoint: https://10.20.0.250:6443
 


### PR DESCRIPTION
Throwaway test PR for Plan 05-05 Task 2, Test 3: confirms gate/human-required still applies on an actually-excluded path (regression check) and confirms the new notify-exclusion job fires a HardExclusionBlocked Kubernetes Event. Will be closed and branch deleted immediately after verification.