### PR TITLE
test(05-05): circuit-breaker paused-bucket throwaway test

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
+# gsd-test: 05-05 Test 2 circuit-breaker throwaway test, no-op comment
 metadata:
   name: &app bazarr
   namespace: media


### PR DESCRIPTION
Throwaway test PR for Plan 05-05 Task 2, Test 2: media/bazarr is temporarily paused in circuit-breaker-state.json. Confirms exclusion-gate applies gate/human-required with a circuit-breaker-specific reason (distinct from taxonomy-exclusion reason) for a PR touching a paused bucket. Will be closed and branch deleted, and circuit-breaker-state.json restored to {} immediately after verification.