### PR TITLE
test(05-07): circuit-breaker unblock proof (throwaway, will close)

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -1,5 +1,8 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+# GSD Phase 5 Plan 05-07 Task 3: trivial comment-only edit, throwaway PR to
+# prove circuit-breaker is genuinely unblocked after human re-enable. Not
+# merged.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
Plan 05-07 Task 3: throwaway PR to prove exclusion-gate.yaml's circuit-breaker check no longer blocks kubernetes/apps/media/bazarr/** after the human re-enable (PR #1086, paused:false). Not for merge — will be closed and branch deleted after verification.