### PR TITLE
feat/claude code pod

### DIFF
--- a/kubernetes/apps/tools/claude-code/README.md
+++ b/kubernetes/apps/tools/claude-code/README.md
@@ -184,3 +184,9 @@ Finally, confirm the node appears in the **Tailscale admin console** as `claude-
   kubelet will restart the container.
 - **A missing `CLAUDE_CODE_SSH_AUTHORIZED_KEYS` is not fatal**, but it silently means no ssh and
   no mosh. Check the app logs for the warning if tailnet access does not work.
+- **The tailscale sidecar runs in kernel mode and needs `/dev/net/tun`.** On this cluster that
+  device is handed out by `generic-device-plugin` (same namespace) as the extended resource
+  `squat.ai/tun`, which the sidecar requests — the same pattern `media/qbittorrent` already uses.
+  If the pod sits `Pending` with an insufficient-`squat.ai/tun` event, check that the
+  generic-device-plugin DaemonSet is healthy on the target node; without the device,
+  `tailscaled` cannot create its interface.

--- a/kubernetes/apps/tools/claude-code/README.md
+++ b/kubernetes/apps/tools/claude-code/README.md
@@ -1,0 +1,186 @@
+# claude-code — persistent remote Claude Code workspace
+
+An always-on Claude Code pod in the `tools` namespace. A 20Gi `ceph-block` PVC is mounted at
+`/home/developer`, so `~/.claude` state, git checkouts and the tmux session survive restarts.
+A Tailscale sidecar puts the pod directly on the tailnet.
+
+> **This app cannot go green until the steps in sections 1 and 2 are done by hand.**
+> The container image does not exist yet, and the Doppler keys it needs are not set.
+
+Image source: [`jbaker48/containers`](https://github.com/jbaker48/containers) →
+`containers/claude-code/`.
+
+---
+
+## 1. Prerequisites
+
+### 1a. Doppler secrets
+
+The `claude-code-secret` ExternalSecret pulls every key with the `CLAUDE_CODE_` prefix from the
+`doppler-secrets` ClusterSecretStore. Create these three:
+
+| Key | Required | Where it comes from |
+| --- | --- | --- |
+| `CLAUDE_CODE_GITHUB_TOKEN` | **yes** | GitHub → Settings → Developer settings → Personal access tokens. Scopes: `repo`, `read:packages`, `workflow`. |
+| `CLAUDE_CODE_TS_AUTHKEY` | **yes** | Tailscale admin console → Settings → Keys → Generate auth key. Must be **reusable** and **tagged `tag:k8s`**. |
+| `CLAUDE_CODE_SSH_AUTHORIZED_KEYS` | optional | Contents of your local `~/.ssh/id_ed25519.pub`. Omit it and sshd/mosh are skipped with a warning; `kubectl exec` still works. |
+
+`CLAUDE_CODE_GITHUB_TOKEN` is used twice: as the file the pod reads for `gh auth login`, and as
+the GHCR pull credential (hence `read:packages`).
+
+The PAT is delivered as a **file** at `/var/run/secrets/claude-code/github-token`, never as an
+environment variable. A missing or empty file makes the container exit with a named error
+rather than starting unauthenticated.
+
+### 1b. Tailscale ACL — this is greenfield
+
+**There is no Tailscale anywhere else in this cluster today.** This pod is the first tailnet
+node, so the ACL almost certainly needs editing before it is reachable. In
+**Tailscale admin console → Access Controls**:
+
+```jsonc
+{
+  "tagOwners": {
+    "tag:k8s": ["autogroup:admin"],
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["autogroup:member"],
+      "dst": [
+        "tag:k8s:2222",          // sshd — NOT 22, see the note below
+        "tag:k8s:60000-61000",   // mosh (UDP)
+      ],
+    },
+  ],
+}
+```
+
+> **sshd listens on port 2222, not 22.** The container runs unprivileged as uid 1000 and cannot
+> bind a privileged port. Open `2222/tcp` in the ACL, and pass `-p 2222` to every `ssh` command.
+
+Without a `tagOwners` entry for `tag:k8s` the auth key is rejected outright and the sidecar
+never comes up.
+
+---
+
+## 2. Publishing the image
+
+The container changes are committed but **deliberately unpushed** on the `feat/claude-code`
+branch of the containers repo. Merging that branch to `main` is what triggers the real GHCR
+build, so it is left as your call:
+
+```bash
+git -C /Users/jbaker/git/containers push -u origin feat/claude-code
+gh pr create --repo jbaker48/containers --base main --head feat/claude-code \
+  --title "feat(claude-code): add persistent remote Claude Code workspace image" \
+  --fill
+# review, then merge — the merge is what publishes to GHCR
+```
+
+Watch the build under the repo's **Actions → Build and Publish Containers**. The workflow
+resolves a version per matrix container, so `claude-code` is tagged from the npm dist-tag of
+`@anthropic-ai/claude-code` (e.g. `2.1.232-<sha>`) and never from the Home Assistant version.
+
+## 3. Pin the tag, and check package visibility
+
+`helmrelease.yaml` currently ships `image.tag: latest` because the image did not exist when the
+app was written. After the first successful build:
+
+1. Replace `tag: latest` with the published `<version>-<sha>` tag and commit.
+2. Check visibility at **github.com/users/jbaker48/packages → claude-code → Package settings**.
+   If you make the package **public**, both `app/pullsecret.yaml` and the `imagePullSecrets`
+   entry in `helmrelease.yaml` can be deleted.
+
+---
+
+## 4. First run — manual steps inside the pod
+
+These are one-time and interactive; they cannot be automated because `/login` is a browser flow.
+
+```bash
+kubectl -n tools exec -it deploy/claude-code -c app -- bash
+```
+
+Then, in order:
+
+1. `claude` — start the CLI, run `/login` and complete the browser authentication.
+2. Accept the **workspace trust prompt** for `~/workspace`.
+3. `tmux attach -t claude` — attach to the session the entrypoint created.
+   (If it is somehow missing: `tmux new -s claude`.)
+4. `claude remote-control` — enable remote control.
+5. `/config` — turn on push notifications.
+
+Because `~/.claude` lives on the PVC, none of this has to be repeated after a restart.
+
+---
+
+## 5. Access
+
+**Primary — kubectl:**
+
+```bash
+kubectl -n tools exec -it deploy/claude-code -c app -- tmux attach -t claude
+```
+
+**Tailnet (needs section 1b's ACL and the optional SSH key):**
+
+```bash
+ssh -p 2222 developer@claude-code
+mosh --ssh="ssh -p 2222" developer@claude-code
+```
+
+The sshd host keys are generated once and persisted to `~/.ssh/host_keys`, so the fingerprint is
+stable across restarts and you will not get host-key warnings after a redeploy.
+
+---
+
+## 6. Verification checklist
+
+```bash
+# 1. Secrets synced from Doppler
+kubectl -n tools get externalsecret claude-code-secret
+#    STATUS should read SecretSynced
+
+# 2. Volume bound at the right size
+kubectl -n tools get pvc claude-code
+#    STATUS Bound, CAPACITY 20Gi, STORAGECLASS ceph-block
+
+# 3. Both containers running
+kubectl -n tools get pods -l app.kubernetes.io/name=claude-code
+#    READY should be 2/2
+
+# 4. Tailscale logged in
+kubectl -n tools logs deploy/claude-code -c tailscale | tail -20
+#    look for a successful login and an assigned 100.x.y.z address
+
+# 5. App startup narrated its decisions
+kubectl -n tools logs deploy/claude-code -c app | tail -20
+#    expect "GitHub CLI authenticated", "sshd listening on port 2222",
+#    "tmux session 'claude' created", "Startup complete"
+```
+
+Finally, confirm the node appears in the **Tailscale admin console** as `claude-code` with
+`tag:k8s`.
+
+---
+
+## 7. Known gotchas
+
+- **The PVC masks `/home/developer`.** Anything baked into the image under that path is invisible
+  at runtime. This is exactly why the Claude CLI is installed to `/opt/claude` and exposed via
+  `/usr/local/bin/claude` — a CLI installed into the home directory would vanish the moment the
+  volume mounted.
+- **`strategy: Recreate` is mandatory, not stylistic.** The PVC is ReadWriteOnce, so a
+  RollingUpdate would deadlock forever on a Multi-Attach error. A restart is therefore a full
+  stop-then-start with brief downtime.
+- **The entrypoint never overwrites `~/.claude`.** That is deliberate — it protects your state.
+  The flip side is that a genuinely corrupted state directory must be cleared by hand:
+  `kubectl -n tools exec -it deploy/claude-code -c app -- rm -rf ~/.claude`, then restart.
+- **The GSD install is best-effort.** It runs after tmux and sshd are already up and is bounded
+  by a timeout, so a dead npm registry warns and moves on instead of crash-looping the pod.
+  Re-run `npx --yes get-shit-done-cc --claude --global` inside the pod to retry.
+- **Liveness is `tmux has-session -t claude`.** If you deliberately kill the tmux session, the
+  kubelet will restart the container.
+- **A missing `CLAUDE_CODE_SSH_AUTHORIZED_KEYS` is not fatal**, but it silently means no ssh and
+  no mosh. Check the app logs for the warning if tailnet access does not work.

--- a/kubernetes/apps/tools/claude-code/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/claude-code/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-code-secret
+  namespace: tools
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-secrets
+  target:
+    name: claude-code-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Delivered to the pod as FILES under /var/run/secrets/claude-code.
+        # The PAT must never become an environment variable.
+        github-token: "{{ .CLAUDE_CODE_GITHUB_TOKEN }}"
+        ssh-authorized-keys: "{{ .CLAUDE_CODE_SSH_AUTHORIZED_KEYS }}"
+        # Consumed by the tailscale sidecar via secretKeyRef, not by the app.
+        ts-authkey: "{{ .CLAUDE_CODE_TS_AUTHKEY }}"
+  dataFrom:
+    - find:
+        path: CLAUDE_CODE_

--- a/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
@@ -108,12 +108,17 @@ spec:
               capabilities:
                 add:
                   - NET_ADMIN
+            # squat.ai/tun is how this cluster hands /dev/net/tun to a container
+            # (generic-device-plugin in this namespace; same pattern as
+            # media/qbittorrent). Kernel-mode tailscaled cannot start without it.
             resources:
               requests:
                 cpu: 10m
                 memory: 64Mi
+                squat.ai/tun: "1"
               limits:
                 memory: 256Mi
+                squat.ai/tun: "1"
 
     # No service and no route: access is via kubectl exec and the tailnet, never
     # the cluster gateway.

--- a/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
@@ -1,0 +1,149 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app claude-code
+  namespace: tools
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+    namespace: tools
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: claude-code-ghcr-pull-secret
+      # No pod-level runAsNonRoot/readOnlyRootFilesystem: the tailscale sidecar
+      # needs root and NET_ADMIN. Hardening is applied per container instead.
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # Mandatory, not stylistic: the PVC is ReadWriteOnce, so a RollingUpdate
+        # would deadlock forever on Multi-Attach.
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/jbaker48/claude-code
+              # TODO: pin to the published <version>-<sha> tag once the first
+              # GHCR build runs. The image does not exist until the containers
+              # repo's feat/claude-code branch is merged — see README.md.
+              tag: latest
+            env:
+              GIT_USER_NAME: Jon Baker
+              GIT_USER_EMAIL: jonbaker85@gmail.com
+              TMUX_SESSION: &tmuxSession claude
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              allowPrivilegeEscalation: false
+            # The container serves no HTTP port, so a default TCP/HTTP probe
+            # would fail against a port nothing listens on. Liveness instead
+            # asserts the thing that actually defines a healthy workspace: the
+            # long-lived tmux session. The anchor keeps it in sync with the env.
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - tmux
+                      - has-session
+                      - -t
+                      - *tmuxSession
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                memory: 6Gi
+
+          # Sidecar shares the pod network namespace, so the tailnet address
+          # reaches sshd/mosh in the app container. Userspace mode would not
+          # accept inbound connections, hence kernel mode + NET_ADMIN.
+          tailscale:
+            image:
+              repository: ghcr.io/tailscale/tailscale
+              tag: v1.102.2
+            env:
+              TS_AUTHKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: claude-code-secret
+                    key: ts-authkey
+              TS_HOSTNAME: *app
+              TS_STATE_DIR: /var/lib/tailscale
+              # Empty on purpose: state lives on the PVC, so the pod needs no
+              # RBAC to write Secrets.
+              TS_KUBE_SECRET: ""
+              TS_USERSPACE: "false"
+              TS_EXTRA_ARGS: --advertise-tags=tag:k8s
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - NET_ADMIN
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+    # No service and no route: access is via kubectl exec and the tailnet, never
+    # the cluster gateway.
+
+    persistence:
+      home:
+        existingClaim: *app
+        advancedMounts:
+          main:
+            app:
+              - path: /home/developer
+            # subPath is load-bearing: without persisted state every restart
+            # registers a brand new tailnet node and suffixes the hostname.
+            tailscale:
+              - path: /var/lib/tailscale
+                subPath: tailscale-state
+      secrets:
+        type: secret
+        name: claude-code-secret
+        # 0440, not 0400: secret volumes are owned root:fsGroup, so with 0400
+        # the app container (uid 1000) could not read its own token.
+        defaultMode: 0440
+        advancedMounts:
+          main:
+            app:
+              - path: /var/run/secrets/claude-code
+                readOnly: true
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          main:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/claude-code/app/helmrelease.yaml
@@ -40,10 +40,10 @@ spec:
           app:
             image:
               repository: ghcr.io/jbaker48/claude-code
-              # TODO: pin to the published <version>-<sha> tag once the first
-              # GHCR build runs. The image does not exist until the containers
-              # repo's feat/claude-code branch is merged — see README.md.
-              tag: latest
+              # <claude-code CLI version>-<containers repo short sha>. Built and
+              # pushed by hand from containers@35d51b7 because Actions is stuck
+              # in that repo (runs queue with zero jobs) — see README.md.
+              tag: 2.1.232-35d51b7
             env:
               GIT_USER_NAME: Jon Baker
               GIT_USER_EMAIL: jonbaker85@gmail.com

--- a/kubernetes/apps/tools/claude-code/app/kustomization.yaml
+++ b/kubernetes/apps/tools/claude-code/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tools
+resources:
+  - ./externalsecret.yaml
+  - ./pullsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/tools/claude-code/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/claude-code/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: claude-code
+  namespace: tools
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/claude-code/app/pullsecret.yaml
+++ b/kubernetes/apps/tools/claude-code/app/pullsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# GHCR packages default to private. This can be deleted (along with the
+# imagePullSecrets entry in helmrelease.yaml) once the claude-code package is
+# made public. It reuses CLAUDE_CODE_GITHUB_TOKEN rather than adding a fourth
+# Doppler secret; that PAT needs read:packages for the pull to succeed.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-code-ghcr-pull-secret
+  namespace: tools
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-secrets
+  target:
+    name: claude-code-ghcr-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      engineVersion: v2
+      data:
+        .dockerconfigjson: '{"auths":{"ghcr.io":{"auth":"{{ printf "jbaker48:%s" .CLAUDE_CODE_GITHUB_TOKEN | b64enc }}"}}}'
+  data:
+    - secretKey: CLAUDE_CODE_GITHUB_TOKEN
+      remoteRef:
+        key: CLAUDE_CODE_GITHUB_TOKEN

--- a/kubernetes/apps/tools/claude-code/app/pvc.yaml
+++ b/kubernetes/apps/tools/claude-code/app/pvc.yaml
@@ -1,0 +1,16 @@
+---
+# Home PVC — backs /home/developer, so it holds ~/.claude state, git checkouts,
+# the persisted sshd host keys and the tailscale sidecar's node identity.
+# ReadWriteOnce is why the controller strategy must be Recreate.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-code
+  namespace: tools
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/tools/claude-code/ks.yaml
+++ b/kubernetes/apps/tools/claude-code/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app claude-code
+  namespace: flux-system
+spec:
+  targetNamespace: tools
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/tools/claude-code/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  # The first pull of a Node-based image plus the entrypoint's optional npx step
+  # is slow; 5m (the repo default) is not enough headroom on a cold node.
+  timeout: 10m

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./claude-code/ks.yaml
   - ./descheduler/ks.yaml
   - ./generic-device-plugin/ks.yaml
   - ./intel-device-plugin/ks.yaml


### PR DESCRIPTION
- **feat(tools): deploy claude-code persistent remote workspace**
- **docs(tools): add claude-code post-deploy runbook**
- **fix(claude-code): request squat.ai/tun so kernel-mode tailscaled can start**
- **fix(claude-code): pin image to 2.1.232-35d51b7**
